### PR TITLE
Remove libtool and instructions since it isn't being used.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,60 @@
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+
+# Mac files
+.DS_Store
+xcuserdata
+*.xcscmblueprint
+
+# Configure intermediate files
+*~
+aclocal.m4
+autom4te.cache
+compile
+config.h.in
+configure
+install-sh
+missing
+depcomp
+.deps
+Makefile.in
+Makefile
+config.log
+config.status
+config.h
+stamp-h1
+INSTALL
+
+# stubby specific
+stubby
+

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ git clone https://github.com/getdnsapi/stubby.git
 Build and install (the paths below assume that getdns is installed in a standard location e.g. by Homebrew in /usr/local/)
 ```
 cd stubby
-libtoolize -ci
 autoreconf -vfi
 ./configure CFLAGS="-I/usr/local/include" LDFLAGS="-L/usr/local/lib"
 make
@@ -198,11 +197,10 @@ for the very latest version of getdns or grab a release tarball from this page: 
 
 ## Build the code
 
-Note that on Mac OS X you will need the developer tools from Xcode to compile the code. And you may need to use brew to install libtool (and then use glibtoolize below), autoconf and automake.
+Note that on Mac OS X you will need the developer tools from Xcode to compile the code. And you may need to use brew to install getdns, autoconf, and automake.
 
 ```sh
 > git submodule update --init
-> libtoolize -ci
 > autoreconf -fi
 > mkdir build
 > cd build

--- a/configure.ac
+++ b/configure.ac
@@ -4,8 +4,7 @@ AM_INIT_AUTOMAKE
 AC_CONFIG_SRCDIR([src/stubby.c])
 AC_CONFIG_HEADERS([config.h])
 
-LT_INIT
-AC_PROG_CC
+AC_PROG_CC([clang gcc])
 
 AC_CHECK_LIB([getdns], [getdns_context_set_logfunc],,
 	[AC_MSG_ERROR([Missing dependency: getdns >= 1.1.2 ])],)


### PR DESCRIPTION
prefer clang over gcc if it's available.