### PR TITLE
Fix tmpfiles.d installation file name

### DIFF
--- a/systemd/README.md
+++ b/systemd/README.md
@@ -12,5 +12,5 @@ running daemon to that user as closely as possible.
 
 Normally, a downstream distributor will install them as:
 
-    /usr/lib/tmpfiles.d/stubby.yml
+    /usr/lib/tmpfiles.d/stubby.conf
     /lib/systemd/system/stubby.service


### PR DESCRIPTION
Looks like it was converted erroneously in https://github.com/getdnsapi/stubby/commit/ac371878f57b0afd63d7a803da726cd89ff063b9#diff-2245b39c177e93fc015ba051be4e8574 to .yaml and subsequently to .yml.