### PR TITLE
Add $(DESTDIR) to config file install path

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-stubbyconfdir = $(sysconfdir)/stubby
+stubbyconfdir = $(DESTDIR)/$(sysconfdir)/stubby
 dist_stubbyconf_DATA = stubby.yml.example
 if ON_MACOS
 dist_sbin_SCRIPTS = stubby-setdns-macos.sh


### PR DESCRIPTION
Fixes GH-26.

Not sure about this though. I’ve never wrote anything for any build toolchains.