### PR TITLE
Windows 7 PowerShell Fix

### DIFF
--- a/windows/stubby_resetdns_windows.ps1
+++ b/windows/stubby_resetdns_windows.ps1
@@ -1,5 +1,16 @@
-﻿Get-NetAdapter -Physical | ForEach-Object {
-   $ifname = $_.Name
-   Write-Host "Resetting DNS servers on interface $ifname - the system will use default DNS service."
-   set-dnsclientserveraddress $ifname -ResetServerAddresses
+#Requires -RunAsAdministrator
+#Requires -Version 2
+
+#Get enabled/connected adapters (same as 'Get-NetAdapter -Physical')
+$NetworkAdapters = Get-WmiObject -Class 'Win32_NetworkAdapterConfiguration' -Filter {IPEnabled = 1}
+
+#Verbose output so the user gets to know the current configuration
+Write-Output -InputObject 'Found Adapters:'
+Write-Output -InputObject $NetworkAdapters | Format-Table -Property IPAddress,DefaultIPGateway,DNSServerSearchOrder,Description
+
+Write-Output -InputObject 'Resetting DNS servers on found interfaces - the system will use default DNS service.'
+
+#Change the DNS entry for each found network adapter
+foreach ($NetworkAdapter in $NetworkAdapters) {
+  $null = $NetworkAdapter.RenewDHCPLease()
 }


### PR DESCRIPTION
This version works on Windows 7 and up since it doesn't depend on any cmdlets not available in PowerShell 2.0.

Script checked against [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) with no errors or warnings.

Resolves Issue #31 