### PR TITLE
Add quad 9 to the config file. At this time only add the IPv4 address…

### DIFF
--- a/stubby.yml.example
+++ b/stubby.yml.example
@@ -151,6 +151,9 @@ upstream_recursive_servers:
 
 # Additional servers
 # IPv4 addresses
+# # Quad 9 service
+#   - address_data: 9.9.9.9
+#     tls_auth_name: "dns.quad9.net"
 # # The Uncensored DNS servers
 #   - address_data: 89.233.43.71
 #     tls_auth_name: "unicast.censurfridns.dk"


### PR DESCRIPTION
… and authentication domain name because Quad9 don’t publish an IPv6 address and have not published a SPKI pinset or stated a policy for key management.