### PR TITLE
Fixed additonal servers commeting / addresses

### DIFF
--- a/stubby.yml.example
+++ b/stubby.yml.example
@@ -151,150 +151,150 @@ upstream_recursive_servers:
 
 # Additional servers
 # IPv4 addresses
-# # Quad 9 service
-#   - address_data: 9.9.9.9
-#     tls_auth_name: "dns.quad9.net"
-# # The Uncensored DNS servers
-#   - address_data: 89.233.43.71
-#     tls_auth_name: "unicast.censurfridns.dk"
-#     tls_pubkey_pinset:
-#       - digest: "sha256"
-#         value: wikE3jYAA6jQmXYTr/rbHeEPmC78dQwZbQp6WdrseEs=
-# # A Surfnet/Sinodun server using Knot resolver. Warning - has issue when used for
-# # DNSSEC
-#   - address_data: 145.100.185.17
-#     tls_auth_name: "dnsovertls2.sinodun.com"
-#     tls_pubkey_pinset:
-#       - digest: "sha256"
-#         value: NAXBESvpjZMnPWQcrxa2KFIkHV/pDEIjRkA3hLWogSg=
-# # dns.cmrg.net server using Knot resolver. Warning - has issue when used for
-# # DNSSEC. (This also listens on port 443)
-#   - address_data: 199.58.81.218
-#     tls_auth_name: "dns.cmrg.net"
-#     tls_pubkey_pinset:
-#       - digest: "sha256"
-#         value: 3IOHSS48KOc/zlkKGtI46a9TY9PPKDVGhE3W2ZS4JZo=
-#       - digest: "sha256"
-#         value: 5zFN3smRPuHIlM/8L+hANt99LW26T97RFHqHv90awjo=
-# # dns1.darkmoon.is
-#   - address_data: 51.15.70.167
-#     tls_auth_name: "dns1.darkmoon.is"
-#     tls_pubkey_pinset:
-#       - digest: "sha256"
-#         value: 8sx8niFUiJvMM3C1qLE9cH79TuQQztzMVDtbKjpD/IQ=
-# # securedns.eu
-#   - address_data: 146.185.167.43
-#     tls_auth_name: "securedns.eu"
-#     tls_pubkey_pinset:
-#       - digest: "sha256"
-#         value: 2EfbwDyk2zSnAbBJSpCSWZKKGUD+a6p/yg2bxdC+x2A=
-# # dns-tls.bitwiseshift.net
-#   - address_data: 81.187.221.24
-#     tls_auth_name: "dns-tls.bitwiseshift.net"
-#     tls_pubkey_pinset:
-#       - digest: "sha256"
-#         value: YmcYWZU5dd2EoblZHNf1jTUPVS+uK3280YYCdz4l4wo=
-# # ns1.dnsprivacy.at
-#   - address_data: 194.130.110.185
-#     tls_auth_name: "ns1.dnsprivacy.at"
-#     tls_pubkey_pinset:
-#       - digest: "sha256"
-#         value: vqVQ9TcoR9RDY3TpO0MTXw1YQLjF44zdN3/4PkLwtEY=
-# # ns2.dnsprivacy.at
-#   - address_data: 94.130.110.178
-#     tls_auth_name: "ns2.dnsprivacy.at"
-#     tls_pubkey_pinset:
-#       - digest: "sha256"
-#         value: s5Em89o0kigwfBF1gcXWd8zlATSWVXsJ6ecZfmBDTKg=
-# # Lorraine Data Network  (self-signed cert). Also listens on port 443.
-#   - address_data: 80.67.188.188
-#     tls_pubkey_pinset:
-#       - digest: "sha256"
-#         value: WaG0kHUS5N/ny0labz85HZg+v+f0b/UQ73IZjFep0nM=
-# # NIC Chile (self-signed cert)
-#   - address_data: 200.1.123.46
-#     tls_pubkey_pinset:
-#       - digest: "sha256"
-#         value: sG6kj+XJToXwt1M6+9BeCz1SOj/1/mdZn56OZvCyZZc=
-# # # OARC. Note: this server currently doesn't support strict mode!
-# #   - address_data: 184.105.193.78
-# #     tls_auth_name: "tls-dns-u.odvr.dns-oarc.net"
-# #     tls_pubkey_pinset:
-# #       - digest: "sha256"
-# #         value: pOXrpUt9kgPgbWxBFFcBTbRH2heo2wHwXp1fd4AEVXI=
-# IPv6 addresses
-# # The Uncensored DNS server
-#   - address_data: 2a01:3a0:53:53::0
-#     tls_auth_name: "unicast.censurfridns.dk"
-#     tls_pubkey_pinset:
-#       - digest: "sha256"
-#         value: wikE3jYAA6jQmXYTr/rbHeEPmC78dQwZbQp6WdrseEs=
-# # A Surfnet/Sinodun server using Knot resolver. Warning - has issue when used for
-# # DNSSEC
-#   - address_data: 2001:610:1:40ba:145:100:185:17
-#     tls_auth_name: "dnsovertls2.sinodun.com"
-#     tls_pubkey_pinset:
-#       - digest: "sha256"
-#         value: NAXBESvpjZMnPWQcrxa2KFIkHV/pDEIjRkA3hLWogSg=
-# # dns.cmrg.net server using Knot resolver. Warning - has issue when used for
-# # DNSSEC. (This also listens on port 443)
-#   - address_data: 2001:470:1c:76d::53
-#     tls_auth_name: "dns.cmrg.net"
-#     tls_pubkey_pinset:
-#       - digest: "sha256"
-#         value: 3IOHSS48KOc/zlkKGtI46a9TY9PPKDVGhE3W2ZS4JZo=
-#       - digest: "sha256"
-#         value: 5zFN3smRPuHIlM/8L+hANt99LW26T97RFHqHv90awjo=
-# # securedns.eu
-#   - address_data: 2a03:b0c0:0:1010::e9a:3001
-#     tls_auth_name: "securedns.eu"
-#     tls_pubkey_pinset:
-#       - digest: "sha256"
-#         value: 2EfbwDyk2zSnAbBJSpCSWZKKGUD+a6p/yg2bxdC+x2A=
-# # dns-tls.bitwiseshift.net
-#   - address_data: 2001:8b0:24:24::24
-#     tls_auth_name: "dns-tls.bitwiseshift.net"
-#     tls_pubkey_pinset:
-#       - digest: "sha256"
-#         value: YmcYWZU5dd2EoblZHNf1jTUPVS+uK3280YYCdz4l4wo=
-# # ns1.dnsprivacy.at
-#   - address_data: 2a01:4f8:c0c:3c03::2
-#     tls_auth_name: "ns1.dnsprivacy.at"
-#     tls_pubkey_pinset:
-#       - digest: "sha256"
-#         value: vqVQ9TcoR9RDY3TpO0MTXw1YQLjF44zdN3/4PkLwtEY=
-# # ns2.dnsprivacy.at
-#   - address_data: 2a01:4f8:c0c:3bfc::2
-#     tls_auth_name: "ns2.dnsprivacy.at"
-#     tls_pubkey_pinset:
-#       - digest: "sha256"
-#         value: s5Em89o0kigwfBF1gcXWd8zlATSWVXsJ6ecZfmBDTKg=
-# # Go6Lab
-#   - address_data: 2001:67c:27e4::35
-#     tls_auth_name: "privacydns.go6lab.si"
-#     tls_pubkey_pinset:
-#       - digest: "sha256"
-#         value: g5lqtwHia/plKqWU/Fe2Woh4+7MO3d0JYqYJpj/iYAw=
-# # Lorraine Data Network  (self-signed cert). Also listens on port 443.
-#   - address_data: 2001:913::8
-#     tls_pubkey_pinset:
-#       - digest: "sha256"
-#         value: WaG0kHUS5N/ny0labz85HZg+v+f0b/UQ73IZjFep0nM=
-# # NIC Chile (self-signed cert)
-#   - address_data: 2001:1398:1:0:200:1:123:46
-#     tls_pubkey_pinset:
-#       - digest: "sha256"
-#         value: sG6kj+XJToXwt1M6+9BeCz1SOj/1/mdZn56OZvCyZZc=
-# # Yeti. Note the servers use a different root trust anchor for DNSSEC!
-#   - address_data: 2001:4b98:dc2:43:216:3eff:fea9:41a
-#     tls_auth_name: "dns-resolver.yeti.eu.org"
-#     tls_pubkey_pinset:
-#       - digest: "sha256"
-#         value: YxtXAorQNSo+333ko1ctuXcnpMcplPaOI/GCM+YeMQk=
-# # # OARC. Note: this server currently doesn't support strict mode!
-# #   - address_data: 2620:ff:c000:0:1::64:25
-# #     tls_auth_name: "tls-dns-u.odvr.dns-oarc.net"
-# #     tls_pubkey_pinset:
-# #       - digest: "sha256"
-# #         value: pOXrpUt9kgPgbWxBFFcBTbRH2heo2wHwXp1fd4AEVXI=
+## Quad 9 service
+#  - address_data: 9.9.9.9
+#    tls_auth_name: "dns.quad9.net"
+## The Uncensored DNS servers
+#  - address_data: 89.233.43.71
+#    tls_auth_name: "unicast.censurfridns.dk"
+#    tls_pubkey_pinset:
+#      - digest: "sha256"
+#        value: wikE3jYAA6jQmXYTr/rbHeEPmC78dQwZbQp6WdrseEs=
+## A Surfnet/Sinodun server using Knot resolver. Warning - has issue when used for
+## DNSSEC
+#  - address_data: 145.100.185.17
+#    tls_auth_name: "dnsovertls2.sinodun.com"
+#    tls_pubkey_pinset:
+#      - digest: "sha256"
+#        value: NAXBESvpjZMnPWQcrxa2KFIkHV/pDEIjRkA3hLWogSg=
+## dns.cmrg.net server using Knot resolver. Warning - has issue when used for
+## DNSSEC. (This also listens on port 443)
+#  - address_data: 199.58.81.218
+#    tls_auth_name: "dns.cmrg.net"
+#    tls_pubkey_pinset:
+#      - digest: "sha256"
+#        value: 3IOHSS48KOc/zlkKGtI46a9TY9PPKDVGhE3W2ZS4JZo=
+#      - digest: "sha256"
+#        value: 5zFN3smRPuHIlM/8L+hANt99LW26T97RFHqHv90awjo=
+## dns1.darkmoon.is
+#  - address_data: 51.15.70.167
+#    tls_auth_name: "dns1.darkmoon.is"
+#    tls_pubkey_pinset:
+#      - digest: "sha256"
+#        value: 8sx8niFUiJvMM3C1qLE9cH79TuQQztzMVDtbKjpD/IQ=
+## securedns.eu
+#  - address_data: 146.185.167.43
+#    tls_auth_name: "securedns.eu"
+#    tls_pubkey_pinset:
+#      - digest: "sha256"
+#        value: 2EfbwDyk2zSnAbBJSpCSWZKKGUD+a6p/yg2bxdC+x2A=
+## dns-tls.bitwiseshift.net
+#  - address_data: 81.187.221.24
+#    tls_auth_name: "dns-tls.bitwiseshift.net"
+#    tls_pubkey_pinset:
+#      - digest: "sha256"
+#        value: YmcYWZU5dd2EoblZHNf1jTUPVS+uK3280YYCdz4l4wo=
+## ns1.dnsprivacy.at
+#  - address_data: 94.130.110.185
+#    tls_auth_name: "ns1.dnsprivacy.at"
+#    tls_pubkey_pinset:
+#      - digest: "sha256"
+#        value: vqVQ9TcoR9RDY3TpO0MTXw1YQLjF44zdN3/4PkLwtEY=
+## ns2.dnsprivacy.at
+#  - address_data: 94.130.110.178
+#    tls_auth_name: "ns2.dnsprivacy.at"
+#    tls_pubkey_pinset:
+#      - digest: "sha256"
+#        value: s5Em89o0kigwfBF1gcXWd8zlATSWVXsJ6ecZfmBDTKg=
+## Lorraine Data Network  (self-signed cert). Also listens on port 443.
+#  - address_data: 80.67.188.188
+#    tls_pubkey_pinset:
+#      - digest: "sha256"
+#        value: WaG0kHUS5N/ny0labz85HZg+v+f0b/UQ73IZjFep0nM=
+## NIC Chile (self-signed cert)
+#  - address_data: 200.1.123.46
+#    tls_pubkey_pinset:
+#      - digest: "sha256"
+#        value: sG6kj+XJToXwt1M6+9BeCz1SOj/1/mdZn56OZvCyZZc=
+## # OARC. Note: this server currently doesn't support strict mode!
+##   - address_data: 184.105.193.78
+##     tls_auth_name: "tls-dns-u.odvr.dns-oarc.net"
+##     tls_pubkey_pinset:
+##       - digest: "sha256"
+##         value: pOXrpUt9kgPgbWxBFFcBTbRH2heo2wHwXp1fd4AEVXI=
+#IPv6 addresses
+## The Uncensored DNS server
+#  - address_data: 2a01:3a0:53:53::0
+#    tls_auth_name: "unicast.censurfridns.dk"
+#    tls_pubkey_pinset:
+#      - digest: "sha256"
+#        value: wikE3jYAA6jQmXYTr/rbHeEPmC78dQwZbQp6WdrseEs=
+## A Surfnet/Sinodun server using Knot resolver. Warning - has issue when used for
+## DNSSEC
+#  - address_data: 2001:610:1:40ba:145:100:185:17
+#    tls_auth_name: "dnsovertls2.sinodun.com"
+#    tls_pubkey_pinset:
+#      - digest: "sha256"
+#        value: NAXBESvpjZMnPWQcrxa2KFIkHV/pDEIjRkA3hLWogSg=
+## dns.cmrg.net server using Knot resolver. Warning - has issue when used for
+## DNSSEC. (This also listens on port 443)
+#  - address_data: 2001:470:1c:76d::53
+#    tls_auth_name: "dns.cmrg.net"
+#    tls_pubkey_pinset:
+#      - digest: "sha256"
+#        value: 3IOHSS48KOc/zlkKGtI46a9TY9PPKDVGhE3W2ZS4JZo=
+#      - digest: "sha256"
+#        value: 5zFN3smRPuHIlM/8L+hANt99LW26T97RFHqHv90awjo=
+## securedns.eu
+#  - address_data: 2a03:b0c0:0:1010::e9a:3001
+#    tls_auth_name: "securedns.eu"
+#    tls_pubkey_pinset:
+#      - digest: "sha256"
+#        value: 2EfbwDyk2zSnAbBJSpCSWZKKGUD+a6p/yg2bxdC+x2A=
+## dns-tls.bitwiseshift.net
+#  - address_data: 2001:8b0:24:24::24
+#    tls_auth_name: "dns-tls.bitwiseshift.net"
+#    tls_pubkey_pinset:
+#      - digest: "sha256"
+#        value: YmcYWZU5dd2EoblZHNf1jTUPVS+uK3280YYCdz4l4wo=
+## ns1.dnsprivacy.at
+#  - address_data: 2a01:4f8:c0c:3c03::2
+#    tls_auth_name: "ns1.dnsprivacy.at"
+#    tls_pubkey_pinset:
+#      - digest: "sha256"
+#        value: vqVQ9TcoR9RDY3TpO0MTXw1YQLjF44zdN3/4PkLwtEY=
+## ns2.dnsprivacy.at
+#  - address_data: 2a01:4f8:c0c:3bfc::2
+#    tls_auth_name: "ns2.dnsprivacy.at"
+#    tls_pubkey_pinset:
+#      - digest: "sha256"
+#        value: s5Em89o0kigwfBF1gcXWd8zlATSWVXsJ6ecZfmBDTKg=
+## Go6Lab
+#  - address_data: 2001:67c:27e4::35
+#    tls_auth_name: "privacydns.go6lab.si"
+#    tls_pubkey_pinset:
+#      - digest: "sha256"
+#        value: g5lqtwHia/plKqWU/Fe2Woh4+7MO3d0JYqYJpj/iYAw=
+## Lorraine Data Network  (self-signed cert). Also listens on port 443.
+#  - address_data: 2001:913::8
+#    tls_pubkey_pinset:
+#      - digest: "sha256"
+#        value: WaG0kHUS5N/ny0labz85HZg+v+f0b/UQ73IZjFep0nM=
+## NIC Chile (self-signed cert)
+#  - address_data: 2001:1398:1:0:200:1:123:46
+#    tls_pubkey_pinset:
+#      - digest: "sha256"
+#        value: sG6kj+XJToXwt1M6+9BeCz1SOj/1/mdZn56OZvCyZZc=
+## Yeti. Note the servers use a different root trust anchor for DNSSEC!
+#  - address_data: 2001:4b98:dc2:43:216:3eff:fea9:41a
+#    tls_auth_name: "dns-resolver.yeti.eu.org"
+#    tls_pubkey_pinset:
+#      - digest: "sha256"
+#        value: YxtXAorQNSo+333ko1ctuXcnpMcplPaOI/GCM+YeMQk=
+## # OARC. Note: this server currently doesn't support strict mode!
+##   - address_data: 2620:ff:c000:0:1::64:25
+##     tls_auth_name: "tls-dns-u.odvr.dns-oarc.net"
+##     tls_pubkey_pinset:
+##       - digest: "sha256"
+##         value: pOXrpUt9kgPgbWxBFFcBTbRH2heo2wHwXp1fd4AEVXI=
 


### PR DESCRIPTION
- Changed ns1.dnsprivacy.at address from 194.130.110.185 to 94.130.110.185 (which is the actual address of the server)
- Corrected commenting on the additional servers. The former approach lead to a syntax error if you just remove the comment (the hashtags), because there was an additional whitespace.
  