### PR TITLE
(Optionally) build getdns as a subproject of Stubby

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "getdns"]
+	path = getdns
+	url = https://github.com/getdnsapi/getdns.git
+	branch = master

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 if ON_MACOS
     OPTIONAL_BUILD_SUBDIR = macos
 endif
-SUBDIRS = src $(OPTIONAL_BUILD_SUBDIR)
+SUBDIRS = $(subdirs) src $(OPTIONAL_BUILD_SUBDIR)
 
 stubbyconfdir = $(sysconfdir)/stubby
 dist_stubbyconf_DATA = stubby.yml.example

--- a/README.md
+++ b/README.md
@@ -21,10 +21,7 @@ See [Stubby Homepage](https://dnsprivacy.org/wiki/x/JYAT) for more details
 
 Stubby uses [getdns](https://getdnsapi.net/) and requires the 1.2 release of getdns or later.
 
-It also requires that either
-* getdns was compiled with [yaml](http://pyyaml.org/wiki/LibYAML) support (using the --with-libyaml configure option)
-* or stubby is compiled with libyaml as a dependancy. 
-
+Stubby also requires [libyaml](https://github.com/yaml/libyaml).
 
 # Installing Using a Package Manager
 
@@ -35,23 +32,33 @@ https://repology.org/metapackage/stubby/versions
 * A Homebrew package for stubby is now available (`brew install stubby`).
 * A [GUI for macOS](https://dnsprivacy.org/wiki/x/CIBn) is also available for testing
 
-If you need to install getdns from source, see the section [at the end of this document.](#building-getdns-from-source)
+If you need to install getdns from source, it can be built as part of the stubby build. See the section [at the end of this document](#building-stubby-with-a-local-build-of-getdns).
 
 # Build Stubby from source
 
 Get the code:
-```
+
+```sh
 git clone https://github.com/getdnsapi/stubby.git
 ```
 
-Build and install (the paths below assume that getdns and libyaml are installed in a standard location e.g. by Homebrew in /usr/local/)
-```
+Build and install:
+
+```sh
 cd stubby
 autoreconf -vfi
-./configure CFLAGS="-I/usr/local/include" LDFLAGS="-L/usr/local/lib"
+./configure
 make
 sudo make install
-````
+```
+
+If getdns or libyaml are installed at non-standard locations, it may be
+necessary to specify the include and library paths. In this example,
+libyaml has been installed into `/opt/yaml`:
+
+```sh
+./configure CFLAGS="-I/opt/yaml/include" LDFLAGS="-L/opt/yaml/lib"
+```
 
 # Configure Stubby
 
@@ -194,10 +201,41 @@ Instructions for how to update the resolvers manually are provided are also prov
 * If Stubby works for a while but you then see failures from Stubby such as "None of the configured upstreams could be used to send queries on the specified transports" try restarting Stubby.
 * If you are using a DNS Privacy server that does not support concurrent processing of TLS queries, you may experience some issues due to timeouts causing subsequent queries on the same connection to fail.
 
-# Building getdns from Source
+# Building stubby with a local build of getdns
 
-Note that from getdns 1.1.3 stubby is included in the getdns code as a git submodule. Therefore stubby and getdns can be built together by following the
-instructions below but adding the ``--with-stubby`` flag to the `configure` step.
+As a convenience to stubby and getdns developers, stubby can be built with a
+local copy of getdns. In this case, assuming the local copy of getdns is only
+for use with stubby, we recommend configuring with the getdns option
+`--enable-stub-only` to minimise getdns dependencies.
+
+Get the code:
+
+```sh
+git clone https://github.com/getdnsapi/stubby.git
+```
+
+Prepare stubby and getdns:
+
+```sh
+cd stubby
+git submodule update --init --recursive
+autoreconf -vfi
+```
+
+Configure and build stubby and getdns:
+
+```sh
+./configure --enable-stub-only
+make
+```
+
+Note that if you then choose to run:
+
+```sh
+sudo make install
+```
+
+this will install stubby AND the local getdns.
 
 ## Dependencies
 
@@ -209,22 +247,11 @@ It may be necessary to install [1.0.2 from source](https://openssl.org/source/op
 
 ### OS X
 
-It is recommended to [install OpenSSL using homebrew](http://brewformulas.org/Openssl), in which case use the following in the `configure` line in the build step below:
+It is recommended to [install OpenSSL using homebrew](http://brewformulas.org/Openssl), in which case use the following parameter to `configure`:
 
 ```sh
 --with-ssl=/usr/local/opt/openssl/
 ```
-
-## Download the getdns source
-
-Either clone the code:
-
-```sh
-> git clone https://github.com/getdnsapi/getdns.git
-> cd getdns
-> git checkout develop
-```
-for the very latest version of getdns or grab a release tarball from this page: [Latest getdns releases](https://getdnsapi.net/releases/)
 
 ## Build the code
 
@@ -235,7 +262,7 @@ Note that on Mac OS X you will need the developer tools from Xcode to compile th
 > autoreconf -fi
 > mkdir build
 > cd build
-> ../configure --prefix=<install_location> --without-libidn --enable-stub-only
+> ../configure --prefix=<install_location> --enable-stub-only
 > make
 > sudo make install
 ```

--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,11 @@ AS_IF([test -f "$srcdir/getdns/configure.ac"],
      [AC_MSG_ERROR([Missing dependency getdns development headers])],)])
 AM_CONDITIONAL([GETDNS_LOCAL], [test $getdns_local -eq 1])
 
+# We need to link against OpenSSL if using a pre-built getdns. Enable
+# the --with-ssl option as per getdns.
+ACX_WITH_SSL_OPTIONAL
+ACX_LIB_SSL
+
 # Autoconf 2.70 will have set up runstatedir. 2.69 is frequently (Debian)
 # patched to do the same, but frequently (MacOS) not. So add a with option
 # for pid file location, and default it to runstatedir if present.
@@ -145,10 +150,6 @@ AH_BOTTOM([
 #else /* !HAVE_ATTR_UNUSED */
 #  define ATTR_UNUSED(x)  x
 #endif /* !HAVE_ATTR_UNUSED */
-
-#ifndef HAVE_GETDNS_YAML2DICT
-# define USE_YAML_CONFIG 1
-#endif
 
 #define yaml_string_to_json_string        stubby_yaml_string_to_json_string
 

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,23 @@ AM_INIT_AUTOMAKE
 AC_CONFIG_SRCDIR([src/stubby.c])
 AC_CONFIG_HEADERS([config.h])
 
+# Nedd to use libtool to retrieve getdns library if local.
+AC_CONFIG_MACRO_DIRS([m4])
+AC_PROG_LIBTOOL
+
+getdns_local=0
+AS_IF([test -f "$srcdir/getdns/configure.ac"],
+  [AC_CONFIG_SUBDIRS([getdns])
+   AC_SUBST([getdnslib], [getdns/src/libgetdns.la])
+   AC_SUBST([getdnsincdir], [getdns/src])
+   getdns_local=1],
+  [AC_CHECK_LIB([getdns], [getdns_context_set_trust_anchors_url],,
+     [AC_MSG_ERROR([Missing dependency: getdns >= 1.2.0])],
+     [])
+   AC_CHECK_HEADERS([getdns/getdns_extra.h],,
+     [AC_MSG_ERROR([Missing dependency getdns development headers])],)])
+AM_CONDITIONAL([GETDNS_LOCAL], [test $getdns_local -eq 1])
+
 # Autoconf 2.70 will have set up runstatedir. 2.69 is frequently (Debian)
 # patched to do the same, but frequently (MacOS) not. So add a with option
 # for pid file location, and default it to runstatedir if present.
@@ -18,15 +35,8 @@ AC_SUBST([runstatedir], [$with_piddir])
 
 AC_PROG_CC([clang gcc])
 
-AC_CHECK_LIB([getdns], [getdns_context_set_trust_anchors_url],,
-    [AC_MSG_ERROR([Missing dependency: getdns >= 1.2.0 ])],)
-AC_CHECK_HEADERS([getdns/getdns_extra.h],,
-    [AC_MSG_ERROR([Missing dependency getdns development headers])],)
-AC_CHECK_FUNCS([getdns_yaml2dict],, [
-	AC_CHECK_LIB([yaml], [yaml_parser_parse],,
-	    [AC_MSG_ERROR([Missing dependency: libyaml])])
-])
-AM_CONDITIONAL([WITH_YAML], [test "x$ac_cv_func_getdns_yaml2dict" = xno])
+AC_CHECK_LIB([yaml], [yaml_parser_parse],,
+    [AC_MSG_ERROR([Missing dependency: libyaml])])
 AC_CHECK_HEADERS([assert.h stdio.h stdarg.h inttypes.h])
 
 AC_MSG_CHECKING(whether the C compiler (${CC-cc}) accepts the "format" attribute)

--- a/m4/acx_openssl.m4
+++ b/m4/acx_openssl.m4
@@ -1,0 +1,164 @@
+# Taken from acx_nlnetlabs.m4 - common macros for configure checks
+# Copyright 2009, Wouter Wijngaards, NLnet Labs.   
+# BSD licensed.
+#
+dnl Add a -R to the RUNTIME_PATH.  Only if rpath is enabled and it is
+dnl an absolute path.
+dnl $1: the pathname to add.
+AC_DEFUN([ACX_RUNTIME_PATH_ADD], [
+	if test "x$enable_rpath" = xyes; then
+		if echo "$1" | grep "^/" >/dev/null; then
+			RUNTIME_PATH="$RUNTIME_PATH -R$1"
+		fi
+	fi
+])
+dnl Common code for both ACX_WITH_SSL and ACX_WITH_SSL_OPTIONAL
+dnl Takes one argument; the withval checked in those 2 functions
+dnl sets up the environment for the given openssl path
+AC_DEFUN([ACX_SSL_CHECKS], [
+    withval=$1
+    if test x_$withval != x_no; then
+        AC_MSG_CHECKING(for SSL)
+        if test x_$withval = x_ -o x_$withval = x_yes; then
+            withval="/usr/local/ssl /usr/lib/ssl /usr/ssl /usr/pkg /usr/local /opt/local /usr/sfw /usr"
+        fi
+        for dir in $withval; do
+            ssldir="$dir"
+            if test -f "$dir/include/openssl/ssl.h"; then
+                found_ssl="yes"
+                AC_DEFINE_UNQUOTED([HAVE_SSL], [], [Define if you have the SSL libraries installed.])
+                dnl assume /usr/include is already in the include-path.
+                if test "$ssldir" != "/usr"; then
+                        CPPFLAGS="$CPPFLAGS -I$ssldir/include"
+                        LIBSSL_CPPFLAGS="$LIBSSL_CPPFLAGS -I$ssldir/include"
+                fi
+                break;
+            fi
+        done
+        if test x_$found_ssl != x_yes; then
+            AC_MSG_ERROR(Cannot find the SSL libraries in $withval)
+        else
+            AC_MSG_RESULT(found in $ssldir)
+            HAVE_SSL=yes
+            dnl assume /usr is already in the lib and dynlib paths.
+            if test "$ssldir" != "/usr" -a "$ssldir" != ""; then
+                LDFLAGS="$LDFLAGS -L$ssldir/lib"
+                LIBSSL_LDFLAGS="$LIBSSL_LDFLAGS -L$ssldir/lib"
+                ACX_RUNTIME_PATH_ADD([$ssldir/lib])
+            fi
+        
+            AC_MSG_CHECKING([for HMAC_Update in -lcrypto])
+            LIBS="-lssl -lcrypto $LIBS"
+            LIBSSL_LIBS="-lssl -lcrypto $LIBSSL_LIBS"
+            AC_TRY_LINK(, [
+                int HMAC_Update(void);
+                (void)HMAC_Update();
+              ], [
+                AC_DEFINE([HAVE_HMAC_UPDATE], 1, 
+                          [If you have HMAC_Update])
+                AC_MSG_RESULT(yes)
+              ], [
+                AC_MSG_RESULT(no)
+                # check if -lwsock32 or -lgdi32 are needed.	
+                BAKLIBS="$LIBS"
+                BAKSSLLIBS="$LIBSSL_LIBS"
+                LIBS="$LIBS -lgdi32"
+                LIBSSL_LIBS="$LIBSSL_LIBS -lgdi32"
+                AC_MSG_CHECKING([if -lcrypto needs -lgdi32])
+                AC_TRY_LINK([], [
+                    int HMAC_Update(void);
+                    (void)HMAC_Update();
+                  ],[
+                    AC_DEFINE([HAVE_HMAC_UPDATE], 1, 
+                        [If you have HMAC_Update])
+                    AC_MSG_RESULT(yes) 
+                  ],[
+                    AC_MSG_RESULT(no)
+                    LIBS="$BAKLIBS"
+                    LIBSSL_LIBS="$BAKSSLLIBS"
+                    LIBS="$LIBS -ldl"
+                    LIBSSL_LIBS="$LIBSSL_LIBS -ldl"
+                    AC_MSG_CHECKING([if -lcrypto needs -ldl])
+                    AC_TRY_LINK([], [
+                        int HMAC_Update(void);
+                        (void)HMAC_Update();
+                      ],[
+                        AC_DEFINE([HAVE_HMAC_UPDATE], 1, 
+                            [If you have HMAC_Update])
+                        AC_MSG_RESULT(yes) 
+                      ],[
+                        AC_MSG_RESULT(no)
+                    AC_MSG_ERROR([OpenSSL found in $ssldir, but version 0.9.7 or higher is required])
+                    ])
+                ])
+            ])
+        fi
+        AC_SUBST(HAVE_SSL)
+        AC_SUBST(RUNTIME_PATH)
+    fi
+AC_CHECK_HEADERS([openssl/ssl.h],,, [AC_INCLUDES_DEFAULT])
+AC_CHECK_HEADERS([openssl/err.h],,, [AC_INCLUDES_DEFAULT])
+AC_CHECK_HEADERS([openssl/rand.h],,, [AC_INCLUDES_DEFAULT])
+
+dnl TLS v1.2 requires OpenSSL 1.0.1
+AC_CHECK_FUNC(TLSv1_2_client_method,AC_DEFINE([HAVE_TLS_v1_2], [1],
+    [Define if you have libssl with tls 1.2]),[AC_MSG_WARN([Cannot find TLSv1_2_client_method in libssl library. TLS will not be available.])])
+
+dnl Native OpenSSL hostname verification requires OpenSSL 1.0.2
+AC_CHECK_FUNC(SSL_CTX_get0_param,AC_DEFINE([HAVE_SSL_HN_AUTH], [1],
+    [Define if you have libssl with host name verification]),[AC_MSG_WARN([Cannot find SSL_CTX_get0_param in libssl library. TLS hostname verification will not be available.])])
+])
+
+dnl Check for SSL, where SSL is mandatory
+dnl Adds --with-ssl option, searches for openssl and defines HAVE_SSL if found
+dnl Setup of CPPFLAGS, CFLAGS.  Adds -lcrypto to LIBS. 
+dnl Checks main header files of SSL.
+dnl
+AC_DEFUN([ACX_WITH_SSL],
+[
+AC_ARG_WITH(ssl, AC_HELP_STRING([--with-ssl=pathname],
+                                    [enable SSL (will check /usr/local/ssl
+                            /usr/lib/ssl /usr/ssl /usr/pkg /usr/local /opt/local /usr/sfw /usr)]),[
+        ],[
+            withval="yes"
+        ])
+    if test x_$withval = x_no; then
+	AC_MSG_ERROR([Need SSL library to do digital signature cryptography])
+    fi
+    ACX_SSL_CHECKS($withval)
+])dnl End of ACX_WITH_SSL
+
+dnl Check for SSL, where ssl is optional (--without-ssl is allowed)
+dnl Adds --with-ssl option, searches for openssl and defines HAVE_SSL if found
+dnl Setup of CPPFLAGS, CFLAGS.  Adds -lcrypto to LIBS. 
+dnl Checks main header files of SSL.
+dnl
+AC_DEFUN([ACX_WITH_SSL_OPTIONAL],
+[
+AC_ARG_WITH(ssl, AC_HELP_STRING([--with-ssl=pathname],
+                                [enable SSL (will check /usr/local/ssl
+                                /usr/lib/ssl /usr/ssl /usr/pkg /usr/local /opt/local /usr/sfw /usr)]),[
+        ],[
+            withval="yes"
+        ])
+    ACX_SSL_CHECKS($withval)
+])dnl End of ACX_WITH_SSL_OPTIONAL
+
+dnl Setup to use -lssl
+dnl To use -lcrypto, use the ACX_WITH_SSL setup (before this one).
+AC_DEFUN([ACX_LIB_SSL],
+[
+# check if libssl needs libdl
+BAKLIBS="$LIBS"
+LIBS="-lssl $LIBS"
+AC_MSG_CHECKING([if libssl needs libdl])
+AC_TRY_LINK_FUNC([SSL_CTX_new], [
+	AC_MSG_RESULT([no])
+	LIBS="$BAKLIBS"
+] , [
+	AC_MSG_RESULT([yes])
+	LIBS="$BAKLIBS"
+	AC_SEARCH_LIBS([dlopen], [dl])
+]) ])dnl End of ACX_LIB_SSL
+
+

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,9 +1,10 @@
 bin_PROGRAMS = stubby
 
-AUTOMAKE_OPTIONS = subdir-objects
-if WITH_YAML
-stubby_SOURCES = stubby.c yaml/convert_yaml_to_json.c sldns/sbuffer.c
-else
-stubby_SOURCES = stubby.c
+if GETDNS_LOCAL
+stubby_LDADD = $(top_builddir)/$(getdnslib)
+EXTRA_CFLAGS = -I$(top_builddir)/$(getdnsincdir)
 endif
-AM_CPPFLAGS = -DSTUBBYCONFDIR=\"$(sysconfdir)/stubby\" -DRUNSTATEDIR=\"$(runstatedir)\"
+
+AUTOMAKE_OPTIONS = subdir-objects
+stubby_SOURCES = stubby.c yaml/convert_yaml_to_json.c sldns/sbuffer.c
+stubby_CFLAGS = -DSTUBBYCONFDIR=\"$(sysconfdir)/stubby\" -DRUNSTATEDIR=\"$(runstatedir)\" $(EXTRA_CFLAGS)

--- a/src/stubby.c
+++ b/src/stubby.c
@@ -38,13 +38,10 @@
 #include <signal.h>
 #include <limits.h>
 
-#ifdef HAVE_GETDNS_YAML2DICT
-getdns_return_t getdns_yaml2dict(const char *str, getdns_dict **dict);
-#else
 # include "yaml/convert_yaml_to_json.h"
-# define getdns_yaml2dict stubby_yaml2dict
+
 getdns_return_t
-getdns_yaml2dict(const char *str, getdns_dict **dict)
+stubby_yaml2dict(const char *str, getdns_dict **dict)
 {
 	char *jsonstr;
 	
@@ -60,7 +57,6 @@ getdns_yaml2dict(const char *str, getdns_dict **dict)
 		return GETDNS_RETURN_GENERIC_ERROR;
 	}       
 }
-#endif
 
 #define STUBBYPIDFILE RUNSTATEDIR"/stubby.pid"
 
@@ -174,17 +170,7 @@ static getdns_return_t parse_config(const char *config_str, int yaml_config)
 	getdns_return_t r;
 
 	if (yaml_config) {
-		r = getdns_yaml2dict(config_str, &config_dict);
-		if (r == GETDNS_RETURN_NOT_IMPLEMENTED) {
-			/* If this fails then YAML is really not supported. Check this at 
-			   runtime because it could change under us..... */
-			r = getdns_yaml2dict(config_str, NULL);
-			if (r == GETDNS_RETURN_NOT_IMPLEMENTED) {
-				fprintf(stderr, "Support for YAML configuration files not available because\n");
-				fprintf(stderr, "the version of getdns used was not compiled with YAML support.\n");
-				return GETDNS_RETURN_NOT_IMPLEMENTED;
-			}
-		}
+		r = stubby_yaml2dict(config_str, &config_dict);
 	} else {
 		r = getdns_str2dict(config_str, &config_dict);
 	}


### PR DESCRIPTION
There is a companion PR to remove Stubby as a subproject of getdns.https://github.com/getdnsapi/getdns/pull/378