### PR TITLE
Remove all unnecessary quotes

### DIFF
--- a/stubby.yml.example
+++ b/stubby.yml.example
@@ -63,7 +63,7 @@ idle_timeout: 10000
 # specify a different port
 listen_addresses:
   - 127.0.0.1
-  -  0::1
+  - 0::1
 
 # Instructs stubby to distribute queries across all available name servers. 
 # Set to 0 to treat the upstreams below as an ordered list and use a single
@@ -76,7 +76,7 @@ round_robin_upstreams: 1
 
 # Specify the location of the installed trust anchor file (leave commented out
 # for zero configuration DNSSEC)
-# dnssec_trust_anchors: "/etc/unbound/getdns-root.key"
+# dnssec_trust_anchors: /etc/unbound/getdns-root.key
 
 # Control the maximum number of connection failures that will be permitted
 # before Stubby backs-off from using an individual upstream (default 2)
@@ -117,38 +117,38 @@ upstream_recursive_servers:
 # IPv4 addresses
 # The Surfnet/Sinodun servers
   - address_data: 145.100.185.15
-    tls_auth_name: "dnsovertls.sinodun.com"
+    tls_auth_name: dnsovertls.sinodun.com
     tls_pubkey_pinset:
-      - digest: "sha256"
+      - digest: sha256
         value: 62lKu9HsDVbyiPenApnc4sfmSYTHOVfFgL3pyB+cBL4=
   - address_data: 145.100.185.16
-    tls_auth_name: "dnsovertls1.sinodun.com"
+    tls_auth_name: dnsovertls1.sinodun.com
     tls_pubkey_pinset:
-      - digest: "sha256"
+      - digest: sha256
         value: cE2ecALeE5B+urJhDrJlVFmf38cJLAvqekONvjvpqUA=
 # The getdnsapi.net server
   - address_data: 185.49.141.37
-    tls_auth_name: "getdnsapi.net"
+    tls_auth_name: getdnsapi.net
     tls_pubkey_pinset:
-      - digest: "sha256"
+      - digest: sha256
         value: foxZRnIh9gZpWnl+zEiKa0EJ2rdCGroMWm02gaxSc9Q=
 # IPv6 addresses
 # The Surfnet/Sinodun servers
   - address_data: 2001:610:1:40ba:145:100:185:15
-    tls_auth_name: "dnsovertls.sinodun.com"
+    tls_auth_name: dnsovertls.sinodun.com
     tls_pubkey_pinset:
-      - digest: "sha256"
+      - digest: sha256
         value: 62lKu9HsDVbyiPenApnc4sfmSYTHOVfFgL3pyB+cBL4=
   - address_data: 2001:610:1:40ba:145:100:185:16
-    tls_auth_name: "dnsovertls1.sinodun.com"
+    tls_auth_name: dnsovertls1.sinodun.com
     tls_pubkey_pinset:
-      - digest: "sha256"
+      - digest: sha256
         value: cE2ecALeE5B+urJhDrJlVFmf38cJLAvqekONvjvpqUA=
 # The getdnsapi.net server
   - address_data: 2a04:b900:0:100::38
-    tls_auth_name: "getdnsapi.net"
+    tls_auth_name: getdnsapi.net
     tls_pubkey_pinset:
-      - digest: "sha256"
+      - digest: sha256
         value: foxZRnIh9gZpWnl+zEiKa0EJ2rdCGroMWm02gaxSc9Q=
 
 
@@ -157,261 +157,261 @@ upstream_recursive_servers:
 # IPv4 addresses
 ## Quad 9 'secure' service - Filters, does DNSSEC, doesn't send ECS
 #  - address_data: 9.9.9.9
-#    tls_auth_name: "dns.quad9.net"
+#    tls_auth_name: dns.quad9.net
 ## Quad 9 'insecure' service - No filtering, does DNSSEC, may send ECS (it is 
 ## unclear if it honours the edns_client_subnet_private request from stubby)
 #  - address_data: 9.9.9.10
-#    tls_auth_name: "dns.quad9.net"
+#    tls_auth_name: dns.quad9.net
 ## The Uncensored DNS servers
 #  - address_data: 89.233.43.71
-#    tls_auth_name: "unicast.censurfridns.dk"
+#    tls_auth_name: unicast.censurfridns.dk
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: wikE3jYAA6jQmXYTr/rbHeEPmC78dQwZbQp6WdrseEs=
 ## A Surfnet/Sinodun server supporting TLS 1.2 and 1.3
 #  - address_data: 145.100.185.18
-#    tls_auth_name: "dnsovertls3.sinodun.com"
+#    tls_auth_name: dnsovertls3.sinodun.com
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: 5SpFz7JEPzF71hditH1v2dBhSErPUMcLPJx1uk2svT8=
 ## A Surfnet/Sinodun server using Knot resolver. Warning - has issue when used 
 ## for DNSSEC
 #  - address_data: 145.100.185.17
-#    tls_auth_name: "dnsovertls2.sinodun.com"
+#    tls_auth_name: dnsovertls2.sinodun.com
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: NAXBESvpjZMnPWQcrxa2KFIkHV/pDEIjRkA3hLWogSg=
 ## dns.cmrg.net server using Knot resolver. Warning - has issue when used for
 ## DNSSEC.
 #  - address_data: 199.58.81.218
-#    tls_auth_name: "dns.cmrg.net"
+#    tls_auth_name: dns.cmrg.net
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: 3IOHSS48KOc/zlkKGtI46a9TY9PPKDVGhE3W2ZS4JZo=
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: 5zFN3smRPuHIlM/8L+hANt99LW26T97RFHqHv90awjo=
 ## dns.larsdebruin.net (formerly dns1.darkmoon.is)
 #  - address_data: 51.15.70.167
-#    tls_auth_name: "dns.larsdebruin.net "
+#    tls_auth_name: dns.larsdebruin.net
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: AAT+rHoKx5wQkWhxlfrIybFocBu3RBrPD2/ySwIwmvA=
 ## securedns.eu
 #  - address_data: 146.185.167.43
-#    tls_auth_name: "securedns.eu"
+#    tls_auth_name: securedns.eu
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: 2EfbwDyk2zSnAbBJSpCSWZKKGUD+a6p/yg2bxdC+x2A=
 ## dns-tls.bitwiseshift.net
 #  - address_data: 81.187.221.24
-#    tls_auth_name: "dns-tls.bitwiseshift.net"
+#    tls_auth_name: dns-tls.bitwiseshift.net
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: YmcYWZU5dd2EoblZHNf1jTUPVS+uK3280YYCdz4l4wo=
 ## ns1.dnsprivacy.at
 #  - address_data: 94.130.110.185
-#    tls_auth_name: "ns1.dnsprivacy.at"
+#    tls_auth_name: ns1.dnsprivacy.at
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: vqVQ9TcoR9RDY3TpO0MTXw1YQLjF44zdN3/4PkLwtEY=
 ## ns2.dnsprivacy.at
 #  - address_data: 94.130.110.178
-#    tls_auth_name: "ns2.dnsprivacy.at"
+#    tls_auth_name: ns2.dnsprivacy.at
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: s5Em89o0kigwfBF1gcXWd8zlATSWVXsJ6ecZfmBDTKg=
 ## dns.bitgeek.in 
 #  - address_data: 139.59.51.46
-#    tls_auth_name: "dns.bitgeek.in"
+#    tls_auth_name: dns.bitgeek.in
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: FndaG4ezEBQs4k0Ya3xt3z4BjFEyQHd7B75nRyP1nTs=
 ## Lorraine Data Network  (self-signed cert).
 #  - address_data: 80.67.188.188
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: WaG0kHUS5N/ny0labz85HZg+v+f0b/UQ73IZjFep0nM=
 ## dns.neutopia.org
 #  - address_data: 89.234.186.112
-#    tls_auth_name: "dns.neutopia.org"
+#    tls_auth_name: dns.neutopia.org
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: wTeXHM8aczvhRSi0cv2qOXkXInoDU+2C+M8MpRyT3OI=
 ## NIC Chile (self-signed cert)
 #  - address_data: 200.1.123.46
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: sG6kj+XJToXwt1M6+9BeCz1SOj/1/mdZn56OZvCyZZc=
 ## # OARC. Note: this server currently doesn't support strict mode!
 ##   - address_data: 184.105.193.78
-##     tls_auth_name: "tls-dns-u.odvr.dns-oarc.net"
+##     tls_auth_name: tls-dns-u.odvr.dns-oarc.net
 ##     tls_pubkey_pinset:
-##       - digest: "sha256"
+##       - digest: sha256
 ##         value: pOXrpUt9kgPgbWxBFFcBTbRH2heo2wHwXp1fd4AEVXI=
 
 #IPv6 addresses
 ## Quad 9 'secure' service - Filters, does DNSSEC, doesn't send ECS
 #  - address_data: 2620:fe::fe
-#    tls_auth_name: "dns.quad9.net"
+#    tls_auth_name: dns.quad9.net
 ## Quad 9 'insecure' service - No filtering, does DNSSEC, may send ECS (it is 
 ## unclear if it honours the edns_client_subnet_private request from stubby)
 #  - address_data: 2620:fe::10
-#    tls_auth_name: "dns.quad9.net"
+#    tls_auth_name: dns.quad9.net
 ## The Uncensored DNS server
 #  - address_data: 2a01:3a0:53:53::0
-#    tls_auth_name: "unicast.censurfridns.dk"
+#    tls_auth_name: unicast.censurfridns.dk
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: wikE3jYAA6jQmXYTr/rbHeEPmC78dQwZbQp6WdrseEs=
 ## A Surfnet/Sinodun server supporting TLS 1.2 and 1.3
 #  - address_data: 2001:610:1:40ba:145:100:185:18
-#    tls_auth_name: "dnsovertls3.sinodun.com"
+#    tls_auth_name: dnsovertls3.sinodun.com
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: 5SpFz7JEPzF71hditH1v2dBhSErPUMcLPJx1uk2svT8=
 ## A Surfnet/Sinodun server using Knot resolver. Warning - has issue when used 
 ## for DNSSEC
 #  - address_data: 2001:610:1:40ba:145:100:185:17
-#    tls_auth_name: "dnsovertls2.sinodun.com"
+#    tls_auth_name: dnsovertls2.sinodun.com
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: NAXBESvpjZMnPWQcrxa2KFIkHV/pDEIjRkA3hLWogSg=
 ## dns.cmrg.net server using Knot resolver. Warning - has issue when used for
 ## DNSSEC.
 #  - address_data: 2001:470:1c:76d::53
-#    tls_auth_name: "dns.cmrg.net"
+#    tls_auth_name: dns.cmrg.net
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: 3IOHSS48KOc/zlkKGtI46a9TY9PPKDVGhE3W2ZS4JZo=
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: 5zFN3smRPuHIlM/8L+hANt99LW26T97RFHqHv90awjo=
 ## securedns.eu
 #  - address_data: 2a03:b0c0:0:1010::e9a:3001
-#    tls_auth_name: "securedns.eu"
+#    tls_auth_name: securedns.eu
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: 2EfbwDyk2zSnAbBJSpCSWZKKGUD+a6p/yg2bxdC+x2A=
 ## dns-tls.bitwiseshift.net
 #  - address_data: 2001:8b0:24:24::24
-#    tls_auth_name: "dns-tls.bitwiseshift.net"
+#    tls_auth_name: dns-tls.bitwiseshift.net
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: YmcYWZU5dd2EoblZHNf1jTUPVS+uK3280YYCdz4l4wo=
 ## ns1.dnsprivacy.at
 #  - address_data: 2a01:4f8:c0c:3c03::2
-#    tls_auth_name: "ns1.dnsprivacy.at"
+#    tls_auth_name: ns1.dnsprivacy.at
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: vqVQ9TcoR9RDY3TpO0MTXw1YQLjF44zdN3/4PkLwtEY=
 ## ns2.dnsprivacy.at
 #  - address_data: 2a01:4f8:c0c:3bfc::2
-#    tls_auth_name: "ns2.dnsprivacy.at"
+#    tls_auth_name: ns2.dnsprivacy.at
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: s5Em89o0kigwfBF1gcXWd8zlATSWVXsJ6ecZfmBDTKg=
 ## Go6Lab
 #  - address_data: 2001:67c:27e4::35
-#    tls_auth_name: "privacydns.go6lab.si"
+#    tls_auth_name: privacydns.go6lab.si
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: g5lqtwHia/plKqWU/Fe2Woh4+7MO3d0JYqYJpj/iYAw=
 ## Lorraine Data Network  (self-signed cert). 
 #  - address_data: 2001:913::8
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: WaG0kHUS5N/ny0labz85HZg+v+f0b/UQ73IZjFep0nM=
 ## dns.neutopia.org
 #  - address_data: 2a00:5884:8209::2
-#    tls_auth_name: "dns.neutopia.org"
+#    tls_auth_name: dns.neutopia.org
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: wTeXHM8aczvhRSi0cv2qOXkXInoDU+2C+M8MpRyT3OI=
 ## NIC Chile (self-signed cert)
 #  - address_data: 2001:1398:1:0:200:1:123:46
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: sG6kj+XJToXwt1M6+9BeCz1SOj/1/mdZn56OZvCyZZc=
 ## Yeti. Note the servers use a different root trust anchor for DNSSEC!
 #  - address_data: 2001:4b98:dc2:43:216:3eff:fea9:41a
-#    tls_auth_name: "dns-resolver.yeti.eu.org"
+#    tls_auth_name: dns-resolver.yeti.eu.org
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: YxtXAorQNSo+333ko1ctuXcnpMcplPaOI/GCM+YeMQk=
 ## # OARC. Note: this server currently doesn't support strict mode!
 ##   - address_data: 2620:ff:c000:0:1::64:25
-##     tls_auth_name: "tls-dns-u.odvr.dns-oarc.net"
+##     tls_auth_name: tls-dns-u.odvr.dns-oarc.net
 ##     tls_pubkey_pinset:
-##       - digest: "sha256"
+##       - digest: sha256
 ##         value: pOXrpUt9kgPgbWxBFFcBTbRH2heo2wHwXp1fd4AEVXI=
 
 ## Servers that listen on port 443 (IPv4 and IPv6)
 ## Surfnet/Sinodun servers
 #  - address_data: 145.100.185.15
 #    tls_port: 443
-#    tls_auth_name: "dnsovertls.sinodun.com"
+#    tls_auth_name: dnsovertls.sinodun.com
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: 62lKu9HsDVbyiPenApnc4sfmSYTHOVfFgL3pyB+cBL4=
 #  - address_data: 145.100.185.16
 #    tls_port: 443
-#    tls_auth_name: "dnsovertls1.sinodun.com"
+#    tls_auth_name: dnsovertls1.sinodun.com
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: cE2ecALeE5B+urJhDrJlVFmf38cJLAvqekONvjvpqUA=
 ## dns.cmrg.net server using Knot resolver
 #  - address_data: 199.58.81.218
 #    tls_port: 443
-#    tls_auth_name: "dns.cmrg.net"
+#    tls_auth_name: dns.cmrg.net
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: 3IOHSS48KOc/zlkKGtI46a9TY9PPKDVGhE3W2ZS4JZo=
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: 5zFN3smRPuHIlM/8L+hANt99LW26T97RFHqHv90awjo=
 ## Lorraine Data Network  (self-signed cert)
 #  - address_data: 80.67.188.188
 #    tls_port: 443
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: WaG0kHUS5N/ny0labz85HZg+v+f0b/UQ73IZjFep0nM=
 ## dns.neutopia.org
 #  - address_data: 89.234.186.112
 #    tls_port: 443
-#    tls_auth_name: "dns.neutopia.org"
+#    tls_auth_name: dns.neutopia.org
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: wTeXHM8aczvhRSi0cv2qOXkXInoDU+2C+M8MpRyT3OI=
 ## The Surfnet/Sinodun servers
 #  - address_data: 2001:610:1:40ba:145:100:185:15
 #    tls_port: 443
-#    tls_auth_name: "dnsovertls.sinodun.com"
+#    tls_auth_name: dnsovertls.sinodun.com
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: 62lKu9HsDVbyiPenApnc4sfmSYTHOVfFgL3pyB+cBL4=
 #  - address_data: 2001:610:1:40ba:145:100:185:16
 #    tls_port: 443
-#    tls_auth_name: "dnsovertls1.sinodun.com"
+#    tls_auth_name: dnsovertls1.sinodun.com
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: cE2ecALeE5B+urJhDrJlVFmf38cJLAvqekONvjvpqUA=
 ## dns.cmrg.net server using Knot resolver
 #  - address_data: 2001:470:1c:76d::53
 #    tls_port: 443
-#    tls_auth_name: "dns.cmrg.net"
+#    tls_auth_name: dns.cmrg.net
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: 3IOHSS48KOc/zlkKGtI46a9TY9PPKDVGhE3W2ZS4JZo=
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: 5zFN3smRPuHIlM/8L+hANt99LW26T97RFHqHv90awjo=
 ## Lorraine Data Network (self-signed cert)
 #  - address_data: 2001:913::8
 #    tls_port: 443
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: WaG0kHUS5N/ny0labz85HZg+v+f0b/UQ73IZjFep0nM=
 ## dns.neutopia.org
 #  - address_data: 2a00:5884:8209::2
 #    tls_port: 443
-#    tls_auth_name: "dns.neutopia.org"
+#    tls_auth_name: dns.neutopia.org
 #    tls_pubkey_pinset:
-#      - digest: "sha256"
+#      - digest: sha256
 #        value: wTeXHM8aczvhRSi0cv2qOXkXInoDU+2C+M8MpRyT3OI=


### PR DESCRIPTION
In YAML, it is not necessary to use quotes around strings unless there are special characters. This sample config file had inconsistent quoting, with some things quoted and others not. This commit removes all unnecessary quotes from all strings.