### PR TITLE
Clarify unit of 'timeout' config option.

### DIFF
--- a/stubby.yml.example
+++ b/stubby.yml.example
@@ -70,7 +70,7 @@ edns_client_subnet_private : 1
 # upstream until it becomes unavailable, then use the next one.
 round_robin_upstreams: 1
 
-# EDNS0 option for keepalive idle timeout in ms as specified in
+# EDNS0 option for keepalive idle timeout in milliseconds as specified in
 # https://tools.ietf.org/html/rfc7828
 # This keeps idle TLS connections open to avoid the overhead of opening a new
 # connection for every query.
@@ -91,9 +91,9 @@ idle_timeout: 10000
 # Limit the total number of outstanding queries permitted
 # limit_outstanding_queries: 100
 
-# Specify the timeout on getting a response to an individual request
-# (default 5s)
-# timeout: 1
+# Specify the timeout in milliseconds on getting a response to an individual
+# request (default 5000)
+# timeout: 1000
 
 ################################ LISTEN ADDRESS ################################
 # Set the listen addresses for the stubby DAEMON. This specifies localhost IPv4


### PR DESCRIPTION
The previous text did not make clear that the 'timeout' configuration
option uses milliseconds as units, and the example that was given
could be somewhat misleading.