### PR TITLE
stubby.yml.example: set round_robin_upstreams = 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ idle_timeout: 10000
 listen_addresses:
   - 127.0.0.1
   -  0::1
-round_robin_upstreams: 1
+round_robin_upstreams: 0
 upstream_recursive_servers:
   - address_data: 185.49.141.38
     tls_auth_name: "getdnsapi.net"

--- a/doc/stubby.1.in
+++ b/doc/stubby.1.in
@@ -96,7 +96,7 @@ idle_timeout: 10000
 listen_addresses:
   - 127.0.0.1
   -  0::1
-round_robin_upstreams: 1
+round_robin_upstreams: 0
 upstream_recursive_servers:
   - address_data: 145.100.185.15
     tls_auth_name: "dnsovertls.sinodun.com"

--- a/stubby.yml.example
+++ b/stubby.yml.example
@@ -68,7 +68,7 @@ edns_client_subnet_private : 1
 # better performance in most (but not all) cases.
 # Set to 0 to treat the upstreams below as an ordered list and use a single
 # upstream until it becomes unavailable, then use the next one.
-round_robin_upstreams: 1
+round_robin_upstreams: 0
 
 # EDNS0 option for keepalive idle timeout in milliseconds as specified in
 # https://tools.ietf.org/html/rfc7828


### PR DESCRIPTION
I was recently surprised - almost shocked - to find
`round_robin_upstreams: 1` in the default config on Debian.

I figured I'd start discussion on this topic by opening a PR.
Why is round robin the default instead of a prioritized list?

From my experience, it seems most DNS server lists are prioritized
lists, not round robin. Typically there is a primary DNS server, and
another as fallback. Here are a few examples:

- DHCP DNS servers
- `/etc/resolv.conf`
- `systemd-resolved`

The fact that `stubby` is different than the rest caught me off guard -
I had simply assumed it would use a prioritized list like everyone else.
I feel the average package maintainer would be better off with
`round_robin_upstreams: 0`. Fewer surprises.