### PR TITLE
Support systemd readiness notification at startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,9 +52,12 @@ Makefile
 config.log
 config.status
 config.h
+config.guess
+config.sub
 stamp-h1
 INSTALL
+.dirstamp
 
 # stubby specific
 stubby
-
+stubby.1

--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,11 @@ AC_CHECK_FUNCS([getdns_yaml2dict],, [
 AM_CONDITIONAL([WITH_YAML], [test "x$ac_cv_func_getdns_yaml2dict" = xno])
 AC_CHECK_HEADERS([assert.h stdio.h stdarg.h inttypes.h])
 
+AC_CHECK_HEADERS([systemd/sd-daemon.h])
+AC_CHECK_LIB([systemd], [sd_notify])
+AM_CONDITIONAL([WITH_SYSTEMD],
+	[test "x$ac_cv_func_systemd_sd_notify" = xno -a "x$ac_cv_header_systemd_sd_daemon_h" = xno])
+
 AC_MSG_CHECKING(whether the C compiler (${CC-cc}) accepts the "format" attribute)
 AC_TRY_COMPILE([
 	#include <stdio.h>

--- a/src/stubby.c
+++ b/src/stubby.c
@@ -40,6 +40,9 @@
 #endif
 #include <signal.h>
 #include <limits.h>
+#if defined(HAVE_LIBSYSTEMD)
+#include <systemd/sd-daemon.h>
+#endif
 
 #ifdef HAVE_GETDNS_YAML2DICT
 getdns_return_t getdns_yaml2dict(const char *str, getdns_dict **dict);
@@ -974,6 +977,9 @@ main(int argc, char **argv)
 #ifdef SIGPIPE
 			(void)signal(SIGPIPE, SIG_IGN);
 #endif
+#ifdef HAVE_LIBSYSTEMD
+			sd_notifyf(0, "READY=1\nMAINPID=%u", getpid());
+#endif
 			getdns_context_run(context);
 		}
 	} else
@@ -1020,6 +1026,9 @@ main(int argc, char **argv)
 			       "Starting DAEMON....\n");
 #ifdef SIGPIPE
 		(void)signal(SIGPIPE, SIG_IGN);
+#endif
+#ifdef HAVE_LIBSYSTEMD
+		sd_notify(0, "READY=1");
 #endif
 		getdns_context_run(context);
 	}


### PR DESCRIPTION
(See #196 for more context. Extra commit in there for some trivial .gitignore updates, I hope you don't mind, I can remove it if you do.)

systemd services cannot reliably depend on stubby through systemd
dependencies currently. This is because systemd only knows when the
stubby daemon has started, not when it is ready to serve. In certain
situations with heavy load at startup, there can be a gap of up to
several seconds between "process started" and "sockets listened on".
During that gap, DNS queries are dropped, causing dependent services to
fail their own startup.

To avoid this issue, add support for systemd's sd_notify functionality.
This allows reporting precisely to systemd when the daemon is ready to
serve.

The current logic for when stubby is ready is hacky: we assume that we
are ready to serve before the event loop is started, when it would be
better to do so after the event loop has been started. getdns does not
currently provide any way to register callbacks on the event loop to
report readiness.