### PR TITLE
Improve stubby.xml

### DIFF
--- a/windows/stubby.xml
+++ b/windows/stubby.xml
@@ -33,7 +33,15 @@
   </Settings>
   <Actions Context="Author">
     <Exec>
+      <Command>PowerShell</Command>
+      <Arguments>"Get-NetAdapter -Physical | Set-DnsClientServerAddress -ServerAddresses ('127.0.0.1','::1')"</Arguments>
+    </Exec>
+    <Exec>
       <Command>"%PROGRAMFILES%\Stubby\stubby.bat"</Command>
+    </Exec>
+    <Exec>
+      <Command>PowerShell</Command>
+      <Arguments>"Get-NetAdapter -Physical | Set-DnsClientServerAddress -ResetServerAddresses"</Arguments>
     </Exec>
   </Actions>
 </Task>

--- a/windows/stubby.xml
+++ b/windows/stubby.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
   <Triggers>
-    <BootTrigger>
-      <Enabled>true</Enabled>
-    </BootTrigger>
+    <EventTrigger>
+      <Subscription>&lt;QueryList&gt;&lt;Query Id="0" Path="Microsoft-Windows-NetworkProfile/Operational"&gt;&lt;Select Path="Microsoft-Windows-NetworkProfile/Operational"&gt;*[System[Provider[@Name='Microsoft-Windows-NetworkProfile'] and EventID=10000]]&lt;/Select&gt;&lt;/Query&gt;&lt;/QueryList&gt;</Subscription>
+    </EventTrigger>
   </Triggers>
   <Principals>
     <Principal id="Author">

--- a/windows/stubby.xml
+++ b/windows/stubby.xml
@@ -9,27 +9,11 @@
   <Principals>
     <Principal id="Author">
       <LogonType>S4U</LogonType>
-      <RunLevel>LeastPrivilege</RunLevel>
     </Principal>
   </Principals>
   <Settings>
-    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
     <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
-    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
-    <AllowHardTerminate>true</AllowHardTerminate>
-    <StartWhenAvailable>false</StartWhenAvailable>
-    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
-    <IdleSettings>
-      <StopOnIdleEnd>true</StopOnIdleEnd>
-      <RestartOnIdle>false</RestartOnIdle>
-    </IdleSettings>
-    <AllowStartOnDemand>true</AllowStartOnDemand>
-    <Enabled>true</Enabled>
-    <Hidden>true</Hidden>
-    <RunOnlyIfIdle>false</RunOnlyIfIdle>
-    <WakeToRun>false</WakeToRun>
-    <ExecutionTimeLimit>PT72H</ExecutionTimeLimit>
-    <Priority>7</Priority>
+    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
   </Settings>
   <Actions Context="Author">
     <Exec>

--- a/windows/stubby.xml
+++ b/windows/stubby.xml
@@ -4,6 +4,7 @@
     <EventTrigger>
       <Subscription>&lt;QueryList&gt;&lt;Query Id="0" Path="Microsoft-Windows-NetworkProfile/Operational"&gt;&lt;Select Path="Microsoft-Windows-NetworkProfile/Operational"&gt;*[System[Provider[@Name='Microsoft-Windows-NetworkProfile'] and EventID=10000]]&lt;/Select&gt;&lt;/Query&gt;&lt;/QueryList&gt;</Subscription>
     </EventTrigger>
+    <RegistrationTrigger />
   </Triggers>
   <Principals>
     <Principal id="Author">

--- a/windows/stubby.xml
+++ b/windows/stubby.xml
@@ -8,7 +8,7 @@
   </Triggers>
   <Principals>
     <Principal id="Author">
-      <LogonType>Password</LogonType>
+      <LogonType>S4U</LogonType>
       <RunLevel>LeastPrivilege</RunLevel>
     </Principal>
   </Principals>


### PR DESCRIPTION
This PR come from my [repo](https://github.com/msoxzw/quiet-windows-10/blob/master/sources/%24OEM%24/%241/Software/Tasks/DNS.xml).

From my view, network connection even trigger is more sensible than boot trigger. Moreover, it seems solve the sleep issue. Do not worry that it will run multiple stubby because schedule task default setting is that do not start a new instance.

Additionally, when this task is imported, stubby will run immediately, which, I think, is more user friendly.

Moreover, I feel that it is more advisable to dynamically change DNS according to stubby running situation. 