### PR TITLE
[RFC] feat: add AppArmor profile

### DIFF
--- a/contrib/apparmor/net.getdnsapi.stubby
+++ b/contrib/apparmor/net.getdnsapi.stubby
@@ -1,0 +1,15 @@
+#include <tunables/global>
+
+profile net.getdnsapi.stubby /usr/bin/stubby {
+  #include <abstractions/base>
+  #include <abstractions/nameservice>
+  capability net_bind_service,
+  # config
+  /etc/stubby/stubby.yml r,
+  owner @{HOME}/.stubby.yml r,
+  # static DNSSEC anchors
+  /etc/unbound/getdns-root.key r,
+  # auto-downloaded DNSSEC anchors
+  /var/cache/stubby/{,**} rw,
+  owner @{HOME}/.getdns/{,**} rw,
+}


### PR DESCRIPTION
AppArmor is a mandatory access control mechanism for Linux.
It is used by default on Ubuntu and Debian 10, and available optionally elsewhere.