### PR TITLE
Adapt PR#197 to the new CMake world.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,12 @@ include(CheckIncludeFile)
 include(CheckSymbolExists)
 include(GNUInstallDirs)
 
+# Options.
+find_package(Libsystemd)
+if (Libsystemd_FOUND)
+  option(ENABLE_SYSTEMD "Enable systemd support." ON)
+endif()
+
 # Directories
 if (DEFINED CMAKE_INSTALL_FULL_RUNSTATEDIR)
   set(RUNSTATEDIR "${CMAKE_INSTALL_FULL_RUNSTATEDIR}")
@@ -83,6 +89,9 @@ endif ()
 
 target_include_directories(stubby PRIVATE src ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(stubby PRIVATE Libyaml::Libyaml)
+if (ENABLE_SYSTEMD)
+  target_link_libraries(stubby PRIVATE Libsystemd::Libsystemd)
+endif()
 # Are we being built from getdns? If so, use the build tree getdns.
 if (TARGET getdns)
   target_link_libraries(stubby PRIVATE getdns)

--- a/cmake/include/cmakeconfig.h.in
+++ b/cmake/include/cmakeconfig.h.in
@@ -11,6 +11,8 @@
 
 #cmakedefine HAVE_GETOPT	1
 
+#cmakedefine ENABLE_SYSTEMD     1
+
 #cmakedefine STUBBYCONFDIR      "@STUBBYCONFDIR@"
 #cmakedefine RUNSTATEDIR        "@RUNSTATEDIR@"
 

--- a/cmake/modules/FindLibsystemd.cmake
+++ b/cmake/modules/FindLibsystemd.cmake
@@ -1,0 +1,62 @@
+#[=======================================================================[.rst:
+FindLibsystemd
+----------
+
+Find the Libsystemd library
+
+Imported targets
+^^^^^^^^^^^^^^^^
+
+This module defines the following :prop_tgt:`IMPORTED` targets:
+
+``Libsystemd::Libsystemd``
+  The Libsystemd library, if found.
+
+Result variables
+^^^^^^^^^^^^^^^^
+
+This module will set the following variables in your project:
+
+``Libsystemd_FOUND``
+  If false, do not try to use Libsystemd.
+``LIBSYSTEMD_INCLUDE_DIR``
+  where to find systemd/sd-daemon.h, etc.
+``LIBSYSTEMD_LIBRARIES``
+  the libraries needed to use Libsystemd.
+
+#]=======================================================================]
+
+find_path(LIBSYSTEMD_INCLUDE_DIR systemd/sd-daemon.h
+  HINTS
+  "${LIBSYSTEMD_DIR}"
+  "${LIBSYSTEMD_DIR}/include"
+  )
+
+find_library(LIBSYSTEMD_LIBRARY NAMES systemd libsystemd
+  HINTS
+  "${LIBSYSTEMD_DIR}"
+  "${LIBSYSTEMD_DIR}/lib"
+  )
+
+set(LIBSYSTEMD_LIBRARIES "")
+
+if (LIBSYSTEMD_INCLUDE_DIR AND LIBSYSTEMD_LIBRARY)
+  if (NOT TARGET Libsystemd::Libsystemd)
+    add_library(Libsystemd::Libsystemd UNKNOWN IMPORTED)
+    set_target_properties(Libsystemd::Libsystemd PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${LIBSYSTEMD_INCLUDE_DIR}"
+      INTERFACE_LINK_LIBRARIES "${LIBSYSTEMD_LIBRARIES}"
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+      IMPORTED_LOCATION "${LIBSYSTEMD_LIBRARY}"
+      )
+  endif ()
+endif ()
+
+list(APPEND LIBSYSTEMD_LIBRARIES "${LIBSYSTEMD_LIBRARY}")
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Libsystemd
+  REQUIRED_VARS LIBSYSTEMD_LIBRARIES LIBSYSTEMD_INCLUDE_DIR
+  )
+
+mark_as_advanced(LIBSYSTEMD_INCLUDE_DIR LIBSYSTEMD_LIBRARIES LIBSYSTEMD_LIBRARY)

--- a/src/stubby.c
+++ b/src/stubby.c
@@ -45,6 +45,9 @@
 #else
 #include <unistd.h>
 #endif
+#if defined(ENABLE_SYSTEMD)
+#include <systemd/sd-daemon.h>
+#endif
 
 #ifdef HAVE_GETDNS_YAML2DICT
 getdns_return_t getdns_yaml2dict(const char *str, getdns_dict **dict);
@@ -979,6 +982,9 @@ main(int argc, char **argv)
 #ifdef SIGPIPE
 			(void)signal(SIGPIPE, SIG_IGN);
 #endif
+#ifdef ENABLE_SYSTEMD
+			sd_notifyf(0, "READY=1\nMAINPID=%u", getpid());
+#endif
 			getdns_context_run(context);
 		}
 	} else
@@ -1025,6 +1031,9 @@ main(int argc, char **argv)
 			       "Starting DAEMON....\n");
 #ifdef SIGPIPE
 		(void)signal(SIGPIPE, SIG_IGN);
+#endif
+#ifdef ENABLE_SYSTEMD
+		sd_notify(0, "READY=1");
 #endif
 		getdns_context_run(context);
 	}


### PR DESCRIPTION
systemd services cannot reliably depend on stubby through systemd
dependencies currently. This is because systemd only knows when the
stubby daemon has started, not when it is ready to serve. In certain
situations with heavy load at startup, there can be a gap of up to
several seconds between "process started" and "sockets listened on".
During that gap, DNS queries are dropped, causing dependent services to
fail their own startup.

To avoid this issue, add support for systemd's sd_notify functionality.
This allows reporting precisely to systemd when the daemon is ready to
serve.

The current logic for when stubby is ready is hacky: we assume that we
are ready to serve before the event loop is started, when it would be
better to do so after the event loop has been started. getdns does not
currently provide any way to register callbacks on the event loop to
report readiness.

Fixes #196