### PR TITLE
When getting GetDNS version, ignore semantic versioning pre-release o…

### DIFF
--- a/cmake/modules/FindGetdns.cmake
+++ b/cmake/modules/FindGetdns.cmake
@@ -55,7 +55,7 @@ if (GETDNS_INCLUDE_DIR AND GETDNS_LIBRARY)
 
   if (NOT GETDNS_VERSION AND GETDNS_INCLUDE_DIR AND EXISTS "${GETDNS_INCLUDE_DIR}/getdns/getdns.h")
     file(STRINGS "${GETDNS_INCLUDE_DIR}/getdns/getdns_extra.h" GETDNS_H REGEX "^#define GETDNS_VERSION")
-    string(REGEX REPLACE "^.*GETDNS_VERSION \"([0-9.]+)\".*$" "\\1" GETDNS_VERSION "${GETDNS_H}")
+    string(REGEX REPLACE "^.*GETDNS_VERSION \"([0-9.]+)[A-Za-z0-9.+-]*\".*$" "\\1" GETDNS_VERSION "${GETDNS_H}")
   endif ()
 endif()
 


### PR DESCRIPTION
…r build suffix.

The purpose of the version check is to verify the API supported. Pre-release or build numbers are irrelevant to that. Which is just as well, because CMake doesn't cope with them when doing a version comparison anyway.

Fixes: #223