### PR TITLE
Improve AppArmor profile

### DIFF
--- a/contrib/apparmor/net.getdnsapi.stubby
+++ b/contrib/apparmor/net.getdnsapi.stubby
@@ -3,13 +3,21 @@
 profile net.getdnsapi.stubby /usr/bin/stubby {
   #include <abstractions/base>
   #include <abstractions/nameservice>
+  #include <abstractions/openssl>
+
   capability net_bind_service,
+
   # config
   /etc/stubby/stubby.yml r,
   owner @{HOME}/.stubby.yml r,
+
   # static DNSSEC anchors
   /etc/unbound/getdns-root.key r,
+  @{system_share_dirs}/dns/root.key r,
+
   # auto-downloaded DNSSEC anchors
   /var/cache/stubby/{,**} rw,
   owner @{HOME}/.getdns/{,**} rw,
+
+  #include if exists <local/net.getdnsapi.stubby>
 }


### PR DESCRIPTION
- allow to read @{system_share_dirs}/dns/root.key
- include openssl abstraction
- allow to configure local additions

This changes make it work on debian stable.