### PR TITLE
Allow YAML config to omit quotes around strings.

### DIFF
--- a/stubby.yml.example
+++ b/stubby.yml.example
@@ -154,9 +154,10 @@ listen_addresses:
 # in milliseconds (which defaults to two and a half seconds).
 # trust_anchors_backoff_time: 2500
 
-# Specify the location of the installed trust anchor file to override the 
+# Specify the location of the installed trust anchor files to override the
 # default location (see above)
-# dnssec_trust_anchors: "/etc/unbound/getdns-root.key"
+# dnssec_trust_anchors:
+#   - "/etc/unbound/getdns-root.key"
 
 
 ##################################  UPSTREAMS  ################################


### PR DESCRIPTION
The YAML parser strips the quotes off, but the JSON requires they be present, but only on specific string quantities.