### PR TITLE
stubby.c: Make `run_in_foreground = 1` the default again, as the documentation states

### DIFF
--- a/src/stubby.c
+++ b/src/stubby.c
@@ -104,7 +104,7 @@ main(int argc, char **argv)
 {
 	const char *custom_config_fn = NULL;
 	int print_api_info = 0;
-	int run_in_foreground = 0;
+	int run_in_foreground = 1;
 	int log_connections = 0;
 	int dnssec_validation = 0;
 #if defined(ENABLE_WINDOWS_SERVICE)


### PR DESCRIPTION
Fixes: c409ce32cdc77ddf111b0860bc1a2fc9b149a495