### PR TITLE
Fix parsing of tls_curves_list option

### DIFF
--- a/src/yaml/convert_yaml_to_json.c
+++ b/src/yaml/convert_yaml_to_json.c
@@ -64,6 +64,7 @@ static const char* QUOTE_KEY_VALUES[] = {
 	"tls_ca_path",
 	"tls_cipher_list",
 	"tls_ciphersuites",
+	"tls_curves_list",
 	"appdata_dir",
 	"dnssec_trust_anchors",
 	"tls_auth_name",


### PR DESCRIPTION
Not documented, but can be used globally or per upstream.

Since this is not documented, this was likely forgotten in this new parser. It worked before, but on 0.4.0 it returns:
```
Error parsing config file "/etc/stubby/stubby.yml": Generic error
```

I had to go through trials and errors to find this setting to be the culprit and how to fix that.