### PR TITLE
Upgrade systemd service security

### DIFF
--- a/systemd/stubby.service
+++ b/systemd/stubby.service
@@ -4,6 +4,8 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
+Restart=on-failure
+RestartSec=1
 User=stubby
 DynamicUser=yes
 CacheDirectory=stubby
@@ -11,8 +13,28 @@ WorkingDirectory=/var/cache/stubby
 ExecStart=/usr/bin/stubby
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE
-Restart=on-failure
-RestartSec=1
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateTmp=true
+PrivateUsers=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=invisible
+ProtectSystem=strict
+RestrictAddressFamilies=AF_INET AF_INET6 AF_NETLINK AF_UNIX
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
After being on the bleeding edge when we moved to DynamicUser, it was left a bit rotting… I’ve discovered that by running my periodic security check on my system.

These changes increase the current security scoring (`systemd-analyze security stubby`) from 5.9 MEDIUM to 1.5 OK.

I’ve tested them on my setup, but they should likely be a bit more tested before going for widespread adoption.

Note that they are even a few more settings (like `ProcSubset`, `SecureBits` or `DeviceAllow`) that could be enabled, as well as `SystemCallFilter` that should be further restrained, but I wasn’t confident enough about them (they require deeper knowledge of the code base or more exhaustive testing).