### PR TITLE
Quote IP addresses in "listen_addresses" when building JSON string

### DIFF
--- a/src/yaml/convert_yaml_to_json.c
+++ b/src/yaml/convert_yaml_to_json.c
@@ -71,6 +71,7 @@ static const char* QUOTE_KEY_VALUES[] = {
 	"tls_auth_name",
 	"digest",
 	"resolvconf",
+	"listen_addresses",
 	NULL
 };
 


### PR DESCRIPTION
When combined with https://github.com/getdnsapi/getdns/pull/514 will close #304 and allow writing IP addresses in the form of
```
listen_addresses:
  - ::1@853
  - "[::1]@853"
```