### PR TITLE
Category: Strengthen check for LibIDN2 version in cmake build step

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+* 2022-07-20:
+
+  * Strengthen version checking for LibIDN2 during the cmake step so LibIDN2
+    version 2.3.3 can be properly found.
+
 * 2022-06-: Version 0.4.1
   * Several updates to the servers in the config file:
      * Change `comment` lines on Uncensored server data to more clearly be comments

--- a/cmake/modules/FindLibidn2.cmake
+++ b/cmake/modules/FindLibidn2.cmake
@@ -53,8 +53,8 @@ if (LIBIDN2_INCLUDE_DIR AND LIBIDN2_LIBRARY)
   endif ()
 
   if (NOT LIBIDN2_VERSION AND LIBIDN2_INCLUDE_DIR AND EXISTS "${LIBIDN2_INCLUDE_DIR}/unbound.h")
-    file(STRINGS "${LIBIDN2_INCLUDE_DIR}/idn2.h" LIBIDN2_H REGEX "^#define IDN2_VERSION ")
-    string(REGEX REPLACE "^.*IDN2_VERSION \"([0-9.]+)\".*$" "\\1" LIBIDN2_VERSION "${LIBIDN2_H}")
+    file(STRINGS "${LIBIDN2_INCLUDE_DIR}/idn2.h" LIBIDN2_H REGEX "^[ \t]*#[ \t]*define[ \t]+IDN2_VERSION[ \t]")
+    string(REGEX REPLACE "^.*IDN2_VERSION[ \t]+\"([0-9.]+)\".*$" "\\1" LIBIDN2_VERSION "${LIBIDN2_H}")
   endif ()
 endif()
 


### PR DESCRIPTION
Contains a fix to cmake/modules/FindLibidn2.cmake to properly find the version for LibIDN2 v2.3.3.