### PR TITLE
Reduce log spam when upstream interface is offline

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -418,10 +418,11 @@ static void incoming_request_handler(getdns_context *context,
                     stubby_getdns_strerror(r));
 
         else if ((r = getdns_general(context, qname_str, qtype,
-            qext, msg, &transaction_id, request_cb)))
-                stubby_error("Could not schedule query: %s",
-                    stubby_getdns_strerror(r));
-        else {
+            qext, msg, &transaction_id, request_cb))) {
+                if (r != GETDNS_RETURN_NO_UPSTREAM_AVAILABLE)
+                    stubby_error("Could not schedule query: %s",
+                        stubby_getdns_strerror(r));
+        } else {
                 DEBUG_SERVER("scheduled: %p %"PRIu64" for %s %d\n",
                     (void *)msg, transaction_id, qname_str, (int)qtype);
                 getdns_dict_destroy(qext);


### PR DESCRIPTION
This was the suggested fix to a problem observed in the OpenWrt implementation of stubby (usually embedded in a router), where if the upstream interface went offline, the logs would rapidly be filled with "Could not schedule query". This fix was suggested by Andre Heider via @dhewg (See openwrt/packages#13726)