### PR TITLE
Private users prevents running on systemd

### DIFF
--- a/systemd/stubby.service
+++ b/systemd/stubby.service
@@ -18,7 +18,6 @@ MemoryDenyWriteExecute=true
 NoNewPrivileges=true
 PrivateDevices=true
 PrivateTmp=true
-PrivateUsers=true
 ProtectClock=true
 ProtectControlGroups=true
 ProtectHome=true


### PR DESCRIPTION
Original value does not work on systemd v250, Fedora 36. Does not work on Fedora 38, systemd-252~rc1 either. It prevents the process from successfully binding the socket.