### PR TITLE
fix: Incorrect error message function argument. Should be "list" to match the function's purpose.

### DIFF
--- a/macos/stubby-ui-helper.c
+++ b/macos/stubby-ui-helper.c
@@ -135,7 +135,7 @@ void list()
 #endif
         int err = execl(LAUNCHCTL, LAUNCHCTL, "list", "org.getdns.stubby", NULL);
         if (err == -1)
-                fail_with_errno("stop");
+                fail_with_errno("list");
 }
 
 void dns_stubby()


### PR DESCRIPTION
Incorrect error message function argument. Should be "list" to match the function's purpose.